### PR TITLE
Fix config locations for CentOS7 and RHEL7

### DIFF
--- a/isc_dhcp/map.jinja
+++ b/isc_dhcp/map.jinja
@@ -30,6 +30,10 @@ RedHat:
   logging:
     facility: local7
   defaults_config: /etc/sysconfig/dhcpd
+  config_dir: /etc/dhcp
+  dhcpd_config: /etc/dhcp/dhcpd.conf
+  hosts_config: /etc/dhcp/dhcpd.hosts
+  subnets_config: /etc/dhcp/dhcpd.subnets
   zone: {}
 Darwin:
   pkgs:


### PR DESCRIPTION
Fixes #1 by correctly specifying the config file locations for CentOS / RHEL.