### PR TITLE
Fix support for salt 2019

### DIFF
--- a/isc_dhcp/server.sls
+++ b/isc_dhcp/server.sls
@@ -3,7 +3,7 @@
 
 isc_dhcp_packages:
   pkg.installed:
-  - pkgs: {{ server.pkgs }}
+  - pkgs: {{ server.pkgs|tojson }}
 
 {{ server.defaults_config }}:
   file.managed:


### PR DESCRIPTION
See https://docs.saltstack.com/en/latest/topics/releases/2019.2.0.html#non-backward-compatible-change-to-yaml-renderer

Signed-off-by: M. David Bennett <mdavidbennett@syntheticworks.com>